### PR TITLE
explicitly pull image before running puiparts

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,5 +11,6 @@ else
   else
     ARGS=""
   fi
+  docker pull $2
   piuparts $1 --docker-image $2 ${ARGS}
 fi


### PR DESCRIPTION
avoids the bug described in https://salsa.debian.org/debian/piuparts/-/merge_requests/39