### PR TITLE
Add new input (distribution) and document it

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ The package to run `piuparts` on. Default `"*.changes"`.
 
 The base image to run `piuparts` in. Default `"debian:sid"`.
 
+### `distribution`
+
+The Debian distribution to run `piuparts` in. Default `"sid"`.
+
+`base-image` and `distribution` should match to have a correct piuparts test.
+
 ### `fake-essential-packages`
 
 Packages that should be added to the fake-essential-packages list. Default `""`.

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   base-image:
     description: 'The base-image to run piuparts in'
     default: 'debian:sid'
+  distribution:
+    description: 'The Debian distribution to run piuparts in'
+    default: 'sid'
   fake-essential-packages:
     description: 'Packages that should be added to the fake-essential-packages list'
     default: ''
@@ -17,6 +20,7 @@ runs:
   args:
     - ${{ inputs.package }}
     - ${{ inputs.base-image }}
+    - ${{ inputs.distribution }}
     - ${{ inputs.fake-essential-packages }}
 branding:
   icon: 'repeat'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,13 +4,13 @@ if [ ! -d /var/lib/docker ]; then
   ORIG_CONTAINER=$(docker ps --latest --quiet)
   ORIG_IMAGE=$(docker inspect ${ORIG_CONTAINER} --format '{{.Config.Image}}')
   ORIG_BINDS=$(docker inspect ${ORIG_CONTAINER} --format '-v {{join .HostConfig.Binds " -v "}}')
-  docker run --workdir /github/workspace --rm ${ORIG_BINDS} -v "/var/lib/docker:/var/lib/docker" ${ORIG_IMAGE} "$1" "$2" "$3"
+  docker run --workdir /github/workspace --rm ${ORIG_BINDS} -v "/var/lib/docker:/var/lib/docker" ${ORIG_IMAGE} "$1" "$2" "$3" "$4"
 else
-  if [ -n "$3" ]; then
-    ARGS="--fake-essential-packages $3"
+  if [ -n "$4" ]; then
+    ARGS="--fake-essential-packages $4"
   else
     ARGS=""
   fi
   docker pull $2
-  piuparts $1 --docker-image $2 ${ARGS}
+  piuparts $1 --docker-image $2 --distribution $3 ${ARGS}
 fi


### PR DESCRIPTION
In response to #7, this MR allows to set the `--distribution` passed to piuparts. It's backaward compatible with previous releases of the action and the commit is:

> base-image only covers which container will be used as root filesystem for the tests (via piuparts' --docker-image option). To get the correct execution, piuparts also needs the --distribution option matching the release used in base-image. Therefore, a new distribution input is available.

It passes the workflow and a test run is available at https://github.com/torizon/neofetch-deb/actions/runs/9355247784/job/25749968446#step:8:1